### PR TITLE
Fix compilation on different versions of libzmq and cross compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ path = "examples/zguide/weather_server/main.rs"
 [features]
 unstable = ["clippy"]
 unstable-testing = ["compiletest_rs", "unstable"]
+cross = ["zmq-has/cross"]
 ipc = ["zmq-has/ipc"]
 pgm = ["zmq-has/pgm"]
 tipc = ["zmq-has/tipc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "High-level bindings to the zeromq library"
 repository = "https://github.com/erickt/rust-zmq"
 build = "build.rs"
 
+
 [[example]]
 name = "helloworld_client"
 path = "examples/zguide/helloworld_client/main.rs"
@@ -50,6 +51,13 @@ path = "examples/zguide/weather_server/main.rs"
 [features]
 unstable = ["clippy"]
 unstable-testing = ["compiletest_rs", "unstable"]
+ipc = ["zmq-has/ipc"]
+pgm = ["zmq-has/pgm"]
+tipc = ["zmq-has/tipc"]
+norm = ["zmq-has/norm"]
+curve = ["zmq-has/curve"]
+gssapi = ["zmq-has/gssapi"]
+
 
 [dependencies]
 libc = "0.2.15"
@@ -61,3 +69,6 @@ clippy = { version = "0.*", optional = true }
 [dev-dependencies]
 rand = "*"
 quickcheck = "0.3.1"
+
+[build-dependencies]
+zmq-has= { version = "0.8.0", path = "zmq-has" }

--- a/zmq-has/Cargo.toml
+++ b/zmq-has/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "zmq-has"
+version = "0.8.0"
+authors = [ "cpp.create@gmail.com" ]
+license = "MIT/Apache-2.0"
+description = "Optional glue between rust and zmq"
+repository = "https://github.com/erickt/rust-zmq"
+build = "build.rs"
+
+[features]
+default = []
+cross = []
+ipc = []
+pgm = []
+tipc = []
+norm = []
+curve = []
+gssapi = []
+
+
+[dependencies]
+libc = "0.2.15"
+
+[build-dependencies]
+pkg-config = "0.3"

--- a/zmq-has/build.rs
+++ b/zmq-has/build.rs
@@ -12,7 +12,7 @@ fn main() {
         println!("cargo:rustc-link-search=native={}/lib", prefix);
         println!("cargo:include={}/include", prefix);
         println!("cargo:warning=You are specifying zmq prefix.\
-         rust-zmq will only compile with libzmq versions 4.x. ");
+         rust-zmq will only compile with libzmq versions 4.x. prefix is {}", prefix );
     } else {
         match pkg_config::find_library("libzmq") {
             Ok(pkg) => {

--- a/zmq-has/build.rs
+++ b/zmq-has/build.rs
@@ -1,0 +1,31 @@
+extern crate pkg_config;
+
+use std::env;
+
+fn main() {
+    if cfg!(feature = "cross") {
+        println!("cargo:warning=You are cross compiling rust-zmq.\
+         Can't compile zmq_has, you need to specify features explicitly!. ");
+        println!("cargo:rustc-cfg=cross");
+    }
+    if let Some(prefix) = env::var("LIBZMQ_PREFIX").ok() {
+        println!("cargo:rustc-link-search=native={}/lib", prefix);
+        println!("cargo:include={}/include", prefix);
+        println!("cargo:warning=You are specifying zmq prefix.\
+         rust-zmq will only compile with libzmq versions 4.x. ");
+    } else {
+        match pkg_config::find_library("libzmq") {
+            Ok(pkg) => {
+                println!("{:?}", pkg);
+                if &pkg.version[..3] != "4.1" && &pkg.version[..3] != "4.2" {
+                    println!("cargo:warning=You are compiling rust-zmq \
+                     with older version of libzmq (version {}).\
+                     Can't compile zmq_has, you need to specify features explicitly!. ", &pkg.version[..3]);
+                    println!("cargo:rustc-cfg=olderzmq");
+                }
+            },
+            Err(e) => panic!("Unable to locate libzmq, err={:?}", e),
+        }
+    }
+}
+

--- a/zmq-has/examples/print.rs
+++ b/zmq-has/examples/print.rs
@@ -1,0 +1,7 @@
+extern crate zmq_has;
+use zmq_has::zmq_capabilities;
+
+fn main(){
+
+    println!("zmq has these capablities: {:?}", zmq_capabilities());
+}


### PR DESCRIPTION
When one try to (cross)compile rust-zmq with older (pre 4.0) versions of libzmq build fails with cryptic linking error `can't find -lzmq` when libzmq is in the right place.
It is failing because these versions doesn't have `zmq_has` function. So I introduced `zmq-has` rust crate with function `zmq_capabilities` that returns a `Vec<String>` of capabilities available on current version of libzmq. It is done either by linking to libzmq or by iterating over a list of `zmq-has` features. `zmq-has` features are reexported in `rust-zmq` `Cargo.toml`. So if one have older libzmq, he can still compile crate, manually specifying needed features in his toml.
In case of cross compilation build will fail so one must explicitely state the cross-compilation using newly-added `cross` feature of `rust-zmq`.